### PR TITLE
#33 ServicesMonitoringListener uses incorrect configuration parameter name in @KafkaListener annotation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
     container_name: etl-ems
     restart: "no"
     environment:
-      - SPRING_KAFKA_BOOTSTRAP_SERVERS=etl-kafka:9092
-      - EMS_TOPICS_HEARTBEAT=ems.heartbeat
+      - EMS_KAFKA_BOOTSTRAP_SERVERS=etl-kafka:9092
+      - EMS_KAFKA_TOPICS_HEARTBEAT=ems.heartbeat
       - SPRING_DATASOURCE_URL=jdbc:postgresql://etl-postgres-db:5432/etl
       - SPRING_DATASOURCE_USERNAME=etl
       - SPRING_DATASOURCE_PASSWORD=etl

--- a/etl-management-service/src/main/java/etl/engine/ems/service/monitoring/instance/ServicesMonitoringListener.java
+++ b/etl-management-service/src/main/java/etl/engine/ems/service/monitoring/instance/ServicesMonitoringListener.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
  * reflect the actual services state.
  */
 @Component
-@KafkaListener(groupId = "${ems.kafka.consumer.group}", topics = "${ems.topics.heartbeat}")
+@KafkaListener(groupId = "${ems.kafka.consumer.group}", topics = "${ems.kafka.topics.heartbeat}")
 @RequiredArgsConstructor
 @Slf4j
 public class ServicesMonitoringListener {

--- a/etl-management-service/src/main/resources/application.yaml
+++ b/etl-management-service/src/main/resources/application.yaml
@@ -50,8 +50,8 @@ ems:
   database:
     schema: "${EMS_DATABASE_SCHEMA}"
   kafka:
-    bootstrap-servers: "${SPRING_KAFKA_BOOTSTRAP_SERVERS}"
+    bootstrap-servers: "${EMS_KAFKA_BOOTSTRAP_SERVERS}"
     topics:
-      heartbeat: "${EMS_TOPICS_HEARTBEAT}"
+      heartbeat: "${EMS_KAFKA_TOPICS_HEARTBEAT}"
     consumer:
       group: "${spring.application.name}"

--- a/extract-data-service/src/main/java/etl/engine/extract/config/KafkaConfiguration.java
+++ b/extract-data-service/src/main/java/etl/engine/extract/config/KafkaConfiguration.java
@@ -1,6 +1,7 @@
 package etl.engine.extract.config;
 
 import etl.engine.extract.service.messaging.CustomJsonSerializer;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 
@@ -21,7 +23,7 @@ public class KafkaConfiguration {
     @Value("${eds.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
-    @Value("${eds.topics.heartbeat}")
+    @Value("${eds.kafka.topics.heartbeat}")
     private String heartBeatTopicName;
 
     @Bean
@@ -36,6 +38,18 @@ public class KafkaConfiguration {
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfiguration());
+    }
+
+    /**
+     * The parameter spring.kafka.bootstrap-servers is not used in the application.yaml.
+     * That's the KafkaAdmin client should be created here.
+     * @return KafkaAdmin
+     */
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configuration = new HashMap<>();
+        configuration.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaAdmin(configuration);
     }
 
     @Bean

--- a/extract-data-service/src/main/java/etl/engine/extract/service/messaging/KafkaMessagingService.java
+++ b/extract-data-service/src/main/java/etl/engine/extract/service/messaging/KafkaMessagingService.java
@@ -12,7 +12,7 @@ public class KafkaMessagingService implements MessagingService {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @Value("${eds.topics.heartbeat}")
+    @Value("${eds.kafka.topics.heartbeat}")
     private String heartBeatTopicName;
 
     @Override


### PR DESCRIPTION
ServicesMonitoringListener uses incorrect configuration parameter name in @KafkaListener annotation.

Also, the bug "KafkaAdmin cannot connect to localhost:9092" was fixed.